### PR TITLE
Fix many method calls when Showdown updated to typescript

### DIFF
--- a/Pokemon Showdown Enhanced Tooltips/js/main.js
+++ b/Pokemon Showdown Enhanced Tooltips/js/main.js
@@ -1,3 +1,3 @@
 var ele = document.createElement("script");
-ele.src = chrome.extension.getURL("/js/tooltip.js");
+ele.src = chrome.extension.getURL("/js/showPokemonTooltip.js");
 document.body.appendChild(ele);

--- a/Pokemon Showdown Enhanced Tooltips/manifest.json
+++ b/Pokemon Showdown Enhanced Tooltips/manifest.json
@@ -2,8 +2,8 @@
 	"update_url": "https://clients2.google.com/service/update2/crx",
 	"name": "Pokémon Showdown Enhanced Tooltips",
 	"description": "Displays additional information on tooltips of Pokémon Showdown.",
-	"version": "0.0.0.1",
-	"manifest_version": 2,
+	"version": "0.0.1.0",
+	"manifest_version": 3,
 	"icons": { 
 		"16": "/icons/icon.png",
 		"32": "/icons/icon32.png",
@@ -19,7 +19,7 @@
 		"*://*.psim.us/*"
 	],
 	"web_accessible_resources": [
-		"/js/tooltip.js"
+		"/js/showPokemonTooltip.js"
 	],
 	"content_scripts": [
 		{


### PR DESCRIPTION
Pokemon Showdown's method definition for `BattleTooltips.showPokemonTooltip` was changed along with many core method signatures changing.  This made the `showPokemonTooltip` in this extension break, due to calling methods that no longer existed.

This PR fixes the tooltips!

![image](https://user-images.githubusercontent.com/9970879/55205323-c1d79f00-51a8-11e9-9766-9309bf1b3049.png)

