### PR TITLE
Show base stats

### DIFF
--- a/Pokemon Showdown Enhanced Tooltips/js/main.js
+++ b/Pokemon Showdown Enhanced Tooltips/js/main.js
@@ -1,3 +1,10 @@
+chrome.runtime.sendMessage({method: "getLocalStorage", key: "showBaseStats"}, function (response) {
+  var showBaseStats = document.createElement('div');
+  showBaseStats.setAttribute("id", "pset-showBaseStats");
+  showBaseStats.setAttribute("enabled", response.data ? response.data : "OFF");
+  document.body.appendChild(showBaseStats);
+});
+
 var ele = document.createElement("script");
 ele.src = chrome.extension.getURL("/js/showPokemonTooltip.js");
 document.body.appendChild(ele);

--- a/Pokemon Showdown Enhanced Tooltips/js/settingsMenu.js
+++ b/Pokemon Showdown Enhanced Tooltips/js/settingsMenu.js
@@ -1,0 +1,10 @@
+chrome.contextMenus.removeAll();
+chrome.contextMenus.create({
+      id: "toggleBaseStats",
+      title: "Show Base Stats",
+      type: "checkbox",
+      contexts: ["browser_action"],
+      onclick: function() {
+
+      }
+});

--- a/Pokemon Showdown Enhanced Tooltips/js/settingsMenu.js
+++ b/Pokemon Showdown Enhanced Tooltips/js/settingsMenu.js
@@ -1,10 +1,25 @@
 chrome.contextMenus.removeAll();
 chrome.contextMenus.create({
-      id: "toggleBaseStats",
-      title: "Show Base Stats",
-      type: "checkbox",
-      contexts: ["browser_action"],
-      onclick: function() {
+  id: "showBaseStats",
+  title: "Show Base Stats",
+  type: "checkbox",
+  contexts: ["browser_action"]
+});
 
-      }
+chrome.contextMenus.onClicked.addListener(function (info, tab) {
+  if (info.menuItemId === "showBaseStats") {
+    const checkedString = info.checked ? 'ON' : 'OFF';
+
+    localStorage['showBaseStats'] = checkedString;
+    alert('Show Base Stats: ' + checkedString + "; Please refresh your Pokemon Showdown tab if currently open.");
+  }
+});
+
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+    if (request.method == "getLocalStorage") {
+      sendResponse({data: localStorage[request.key]});
+    }
+    else {
+      sendResponse({});
+    }
 });

--- a/Pokemon Showdown Enhanced Tooltips/js/showPokemonTooltip.js
+++ b/Pokemon Showdown Enhanced Tooltips/js/showPokemonTooltip.js
@@ -1,5 +1,9 @@
 let ShowdownEnhancedTooltip = {};
 
+ShowdownEnhancedTooltip.Settings = {
+	showBaseStats: document.getElementById('pset-showBaseStats').getAttribute('enabled')
+};
+
 ShowdownEnhancedTooltip.BattleTypeChart = {
 	// defending type
 	"Bug": {
@@ -475,6 +479,18 @@ ShowdownEnhancedTooltip.showPokemonTooltip = function showPokemonTooltip(clientP
         text += '<small>(Type changed)</small><br />';
     }
     text += types.map(function (type) { return Dex.getTypeIcon(type); }).join(' ');
+
+    // Show base stats
+		if (ShowdownEnhancedTooltip.Settings.showBaseStats === "ON") {
+			text += '<br /><small>Base stats:' + '<br />';
+			text += 'HP: ' + pokemon.baseStats.hp + ' ';
+			text += 'Atk: ' + pokemon.baseStats.atk + ' ';
+			text += 'Def: ' + pokemon.baseStats.def + ' ';
+			text += 'SpA: ' + pokemon.baseStats.spa + ' ';
+			text += 'SpD: ' + pokemon.baseStats.spd + ' ';
+			text += 'Spe: ' + pokemon.baseStats.spe + '</small>'
+		}
+
     text += '</h2>';
 
     // Show type effectiveness icons

--- a/Pokemon Showdown Enhanced Tooltips/manifest.json
+++ b/Pokemon Showdown Enhanced Tooltips/manifest.json
@@ -21,6 +21,7 @@
 	},
 	"permissions": [
 		"contextMenus",
+		"storage",
 		"*://play.pokemonshowdown.com/*",
 		"*://*.psim.us/*"
 	],

--- a/Pokemon Showdown Enhanced Tooltips/manifest.json
+++ b/Pokemon Showdown Enhanced Tooltips/manifest.json
@@ -11,10 +11,16 @@
 		"64": "/icons/icon64.png",
 		"128": "/icons/icon128.png"
 	},
+	"background": {
+		"scripts": [
+			"/js/settingsMenu.js"
+		]
+	},
 	"browser_action":{
 		"default_icon": "/icons/icon.png"
 	},
 	"permissions": [
+		"contextMenus",
 		"*://play.pokemonshowdown.com/*",
 		"*://*.psim.us/*"
 	],


### PR DESCRIPTION
This PR enables extension users to toggle on/off the showing of pokemon base stats in their tooltips! 

Pretty hacky way of implementing extension settings. There's probably an easier way of getting the `localStorage` setting down into the script, but I used a DOM element here:

1.  Added a contextMenu for the setting
2. Added an onClick listener for the contextMenu that checks the id and then sets the appropriate setting using `localStorage`.  (chrome.storage.sync.get/set wasn't cooperating)
3. Added a general onMessage listener to return setting data from `localStorage` given a method of `getLocalStorage` and a key of whatever setting your trying to get the value
4.  In the main content script, send the message to the background script to get the value of the setting. Shove a div element into the DOM with an id of the setting and an attribute of the setting value.  
5.  In the tooltip script, grab that div element from the DOM and set the ShowdownEnhancedTooltip.Settings variable appropriately
6.  Use the setting from above to conditionally render base stats!