### PR TITLE
Adding base power, type to moves

### DIFF
--- a/Pokemon Showdown Enhanced Tooltips/js/showPokemonTooltip.js
+++ b/Pokemon Showdown Enhanced Tooltips/js/showPokemonTooltip.js
@@ -588,9 +588,9 @@ ShowdownEnhancedTooltip.showPokemonTooltip = function showPokemonTooltip(clientP
     if (serverPokemon && !isActive) {
 
         text += '<p class="section">';
-        var battlePokemon = this.battle.getPokemon(pokemon.ident, pokemon.details); for (var _i4 = 0, _serverPokemon$moves =
-            serverPokemon.moves; _i4 < _serverPokemon$moves.length; _i4++) {
-                var _moveid = _serverPokemon$moves[_i4];
+        var battlePokemon = this.battle.getPokemon(pokemon.ident, pokemon.details);
+        for (var _i4 = 0, _serverPokemon$moves = serverPokemon.moves; _i4 < _serverPokemon$moves.length; _i4++) {
+        	  var _moveid = _serverPokemon$moves[_i4];
             var move = Dex.getMove(_moveid);
             var moveName = '&#8226; ' + move.name;
             if (battlePokemon && battlePokemon.moveTrack) {
@@ -603,19 +603,20 @@ ShowdownEnhancedTooltip.showPokemonTooltip = function showPokemonTooltip(clientP
                     }
                 }
             }
-            text += moveName + '<br />';
+            text += moveName + ', Base power: ' + move.basePower + ' ' + Dex.getTypeIcon(move.type) + '<br />';
         }
         text += '</p>';
     } else if (!this.battle.hardcoreMode && clientPokemon && clientPokemon.moveTrack.length) {
 
-        text += '<p class="section">'; for (var _i6 = 0, _clientPokemon$moveTr =
-            clientPokemon.moveTrack; _i6 < _clientPokemon$moveTr.length; _i6++) {
-                var _row = _clientPokemon$moveTr[_i6];
-            text += this.getPPUseText(_row) + '<br />';
+        text += '<p class="section">';
+        for (var _i6 = 0, _clientPokemon$moveTr = clientPokemon.moveTrack; _i6 < _clientPokemon$moveTr.length; _i6++) {
+						var _row = _clientPokemon$moveTr[_i6];
+						var move = Dex.getMove(_row[0]);
+            text += this.getPPUseText(_row) + ' Base power: ' + move.basePower + ' ' + Dex.getTypeIcon(move.type) + '<br />';
         }
         if (clientPokemon.moveTrack.filter(function (_ref) {
-            var moveName = _ref[0]; return (
-                moveName.charAt(0) !== '*' && !_this3.battle.dex.getMove(moveName).isZ);
+            var moveName = _ref[0];
+            return (moveName.charAt(0) !== '*' && !_this3.battle.dex.getMove(moveName).isZ);
         }).
             length > 4) {
             text += '(More than 4 moves is usually a sign of Illusion Zoroark/Zorua.)';


### PR DESCRIPTION
This addresses #9 and I believe #8. You can now see the move type and base power on yours and opposing Pokemon.

For Pokemon in play, this looks like:

<img width="303" alt="Screen Shot 2019-10-08 at 4 08 47 PM" src="https://user-images.githubusercontent.com/1103622/66433528-1c6a7700-e9e6-11e9-9af2-327313f8d3ba.png">

And for those on the bench, like this:

<img width="309" alt="Screen Shot 2019-10-08 at 4 09 02 PM" src="https://user-images.githubusercontent.com/1103622/66433546-29876600-e9e6-11e9-8937-e7db255818eb.png">

I am open to suggestions on styling or improving this, but it seems like a pretty helpful improvement to the extension. I look forward to hearing your feedback!