### PR TITLE
Fixing get type error by accounting for missing values

### DIFF
--- a/chrome/Pokemon Showdown Enhanced Tooltips/js/showPokemonTooltip.js
+++ b/chrome/Pokemon Showdown Enhanced Tooltips/js/showPokemonTooltip.js
@@ -543,7 +543,8 @@ ShowdownEnhancedTooltip.showPokemonTooltip = function showPokemonTooltip(clientP
     text += '<p>Weaknesses: <br />';
     multiplierKeys.forEach((multiplierKey) => {
         if (typeEff[multiplierKey].length > 0) {
-            text += `<p>${multiplierKey}x: ` + (typeEff[multiplierKey].map(Dex.getTypeIcon).join('')) + '</p>';
+        	  const weakTypes = typeEff[multiplierKey].map(effect => effect ? Dex.getTypeIcon(effect) : '').join('');
+            text += `<p>${multiplierKey}x: ${weakTypes}</p>`;
         }
     });
     text += '</p><h2></h2>';

--- a/chrome/Pokemon Showdown Enhanced Tooltips/js/showPokemonTooltip.js
+++ b/chrome/Pokemon Showdown Enhanced Tooltips/js/showPokemonTooltip.js
@@ -543,7 +543,7 @@ ShowdownEnhancedTooltip.showPokemonTooltip = function showPokemonTooltip(clientP
     text += '<p>Weaknesses: <br />';
     multiplierKeys.forEach((multiplierKey) => {
         if (typeEff[multiplierKey].length > 0) {
-        	  const weakTypes = typeEff[multiplierKey].map(effect => effect ? Dex.getTypeIcon(effect) : '').join('');
+            const weakTypes = typeEff[multiplierKey].map(effect => effect ? Dex.getTypeIcon(effect) : '').join('');
             text += `<p>${multiplierKey}x: ${weakTypes}</p>`;
         }
     });


### PR DESCRIPTION
Addresses #20 

Looks like they removed one of the checks for empty types in the Pokemon Showdown client, which broke our extension here: https://github.com/smogon/pokemon-showdown-client/pull/1545/files#diff-663a94185abd336c47ecbcfee7740fb3

I fixed it by checking that the type was not empty before passing it into the `getTypeIcon` method. Seems to work on Chrome.

I don't have Firefox right now, but I would assume the bug persists over there? We'll need to address that one too I guess.