### PR TITLE
Removing four move limit in gen 8+

### DIFF
--- a/chrome/Pokemon Showdown Enhanced Tooltips/js/showPokemonTooltip.js
+++ b/chrome/Pokemon Showdown Enhanced Tooltips/js/showPokemonTooltip.js
@@ -651,7 +651,7 @@ ShowdownEnhancedTooltip.showPokemonTooltip = function showPokemonTooltip(clientP
 							'<br />';
             // *********************
 			}
-			if (clientPokemon.moveTrack.filter(([moveName]) =>
+			if (this.battle.gen < 8 && clientPokemon.moveTrack.filter(([moveName]) =>
 				moveName.charAt(0) !== '*' && !this.battle.dex.getMove(moveName).isZ
 			).length > 4) {
 				text += `(More than 4 moves is usually a sign of Illusion Zoroark/Zorua.) `;


### PR DESCRIPTION
Dynamax makes 4+ moves common in gen 8 and not a likely sign of Zoroark as we have noted in the comments. This has bugged me for a while, I just kept forgetting to submit this fix.